### PR TITLE
Check for Group bl_rna.name vs bl_rna.identifier

### DIFF
--- a/api/noderegistrar.py
+++ b/api/noderegistrar.py
@@ -12,8 +12,12 @@ import mathutils
 class NodeInfo():
     def __init__(self, node_type):
         self.type = node_type
-        self.func_name = lower_snake_case(node_type.bl_rna.name)
-        self.namespace = title_case(node_type.bl_rna.name)
+        if node_type.bl_rna.name == "Group":
+            name = node_type.bl_rna.identifier
+        else:
+            name = node_type.bl_rna.name
+        self.func_name = lower_snake_case(name)
+        self.namespace = title_case(name)
         self.outputs = {}
         self.primary_arg = None
         self.default_value = defaultdict(lambda: defaultdict(list))


### PR DESCRIPTION
In the new alpha/beta, the `bl_rna.name` attribute for the various `Group` types is just `Group`, rather than the `GeometryNodeGroup` etc.  But, `bl_rna.identifier` does correctly return what is expected.

This change uses `bl_rna.identifier` only for `Group` types, and otherwise uses `bl_rna.name`.
